### PR TITLE
Add mounts option for tinet spec

### DIFF
--- a/internal/pkg/shell/shell.go
+++ b/internal/pkg/shell/shell.go
@@ -53,6 +53,7 @@ type Node struct {
 	Image      string      `yaml:"image"`
 	Interfaces []Interface `yaml:"interfaces" mapstructure:"interfaces"`
 	Sysctls    []Sysctl    `yaml:"sysctls" mapstructure:"sysctls"`
+	Mounts     []string    `yaml:"mounts,flow"`
 }
 
 // Interface
@@ -367,6 +368,13 @@ func CreateNode(node Node) []string {
 				createNodeCmd += fmt.Sprintf("--sysctl %s ", sysctl.Sysctl)
 			}
 		}
+
+		if len(node.Mounts) != 0 {
+			for _, mount := range node.Mounts {
+				createNodeCmd += fmt.Sprintf("-v %s ", mount)
+			}
+		}
+
 		createNodeCmd += node.Image
 	} else if node.Type == "netns" {
 		createNodeCmd = fmt.Sprintf("ip netns add %s", node.Name)
@@ -377,6 +385,13 @@ func CreateNode(node Node) []string {
 				createNodeCmd += fmt.Sprintf("--sysctl %s ", sysctl.Sysctl)
 			}
 		}
+
+		if len(node.Mounts) != 0 {
+			for _, mount := range node.Mounts {
+				createNodeCmd += fmt.Sprintf("-v %s ", mount)
+			}
+		}
+
 		createNodeCmd += node.Image
 	} else {
 		// err := fmt.Errorf("unknown nodetype %s", node.Type)


### PR DESCRIPTION
This pull request add option `mounts` for tinet spec file.

For example, If I want to mount directory as follows:
```
nodes:
  - name: T1
    image: slankdev/frr
    mounts:
      - "`pwd`:/mnt/test"
      -  /usr/share/vim:/mnt/vim
    interfaces:
      - { name: net0, type: direct, args: T2#net0 }
  - name: T2
    image: slankdev/frr
    interfaces:
      - { name: net0, type: direct, args: T1#net0 }
`
```
